### PR TITLE
Removed non existent 'simd_combine.h' from experimental/simd

### DIFF
--- a/experimental/simd
+++ b/experimental/simd
@@ -54,7 +54,6 @@
 #include "bits/simd.h"
 #include "bits/simd_fixed_size.h"
 #include "bits/simd_scalar.h"
-#include "bits/simd_combine.h"
 #include "bits/simd_builtin.h"
 #include "bits/simd_converter.h"
 #if _GLIBCXX_SIMD_X86INTRIN


### PR DESCRIPTION
Hi, I really appreciate your work and tried to install it today.
However, there was a header included which did not exist. This lead to a failure during the test procecure in install. So I just removed it and created this pull request.

Best Regards
Ralf Schleicher