### PR TITLE
add gather/scatter methods for simd

### DIFF
--- a/experimental/bits/simd.h
+++ b/experimental/bits/simd.h
@@ -32,6 +32,7 @@
 
 #include "simd_detail.h"
 #include "numeric_traits.h"
+#include <array>
 #include <bit>
 #include <bitset>
 #ifdef _GLIBCXX_DEBUG_UB
@@ -4966,6 +4967,15 @@ template <typename _Tp, typename _Abi>
 	  _Impl::_S_load(_Flags::template _S_apply<simd>(__mem), _S_type_tag))
       {}
 
+    // gather constructor
+    template <typename _Up, typename _Flags>
+      _GLIBCXX_SIMD_ALWAYS_INLINE
+      simd(const _Up* __mem, const __int_for_sizeof_t<_Up>* __idx, _Flags)
+      : _M_data(
+        _Impl::_S_gather(_Flags::template _S_apply<simd>(__mem),
+			   __idx, _S_type_tag))
+      {}
+
     // loads [simd.load]
     template <typename _Up, typename _Flags>
       _GLIBCXX_SIMD_ALWAYS_INLINE void
@@ -4982,6 +4992,47 @@ template <typename _Tp, typename _Abi>
       {
 	_Impl::_S_store(_M_data, _Flags::template _S_apply<simd>(__mem),
 			_S_type_tag);
+      }
+
+    // gather [simd.gather]
+    template <typename _Up, typename _Flags>
+      _GLIBCXX_SIMD_ALWAYS_INLINE void
+      gather(const _Vectorizable<_Up>* __mem,
+	     const std::array<int, size()>& __idx, _Flags)
+      {
+	_M_data = static_cast<decltype(_M_data)>(
+	  _Impl::_S_gather(_Flags::template _S_apply<simd>(__mem), __idx.data(),
+			   _S_type_tag));
+      }
+
+    template <typename _Up, typename _Flags>
+      _GLIBCXX_SIMD_ALWAYS_INLINE void
+      gather(const _Vectorizable<_Up>* __mem,
+	     const __int_for_sizeof_t<_Up>* __idx, _Flags)
+      {
+	_M_data = static_cast<decltype(_M_data)>(
+	  _Impl::_S_gather(_Flags::template _S_apply<simd>(__mem), __idx,
+			   _S_type_tag));
+      }
+
+    // scatter [simd.scatter]
+    template <typename _Up, typename _Flags>
+      _GLIBCXX_SIMD_ALWAYS_INLINE void
+      scatter(_Vectorizable<_Up>* __mem, std::array<int, size()>& __idx,
+	      _Flags) const
+      {
+	_Impl::_S_scatter(_M_data, _Flags::template _S_apply<simd>(__mem),
+			  __idx.data(), _S_type_tag);
+      }
+
+    // scatter [simd.scatter]
+    template <typename _Up, typename _Flags>
+      _GLIBCXX_SIMD_ALWAYS_INLINE void
+      scatter(_Vectorizable<_Up>* __mem, const __int_for_sizeof_t<_Up>* __idx,
+	      _Flags) const
+      {
+	_Impl::_S_scatter(_M_data, _Flags::template _S_apply<simd>(__mem),
+			  __idx, _S_type_tag);
       }
 
     // scalar access

--- a/experimental/bits/simd_builtin.h
+++ b/experimental/bits/simd_builtin.h
@@ -1431,6 +1431,54 @@ template <typename _Abi>
 	});
       }
 
+    // _S_gather {{{2
+    template <typename _Tp, typename _Up>
+      _GLIBCXX_SIMD_INTRINSIC static _SimdMember<_Tp>
+      _S_gather(const _Up* __mem, const __int_for_sizeof_t<_Up>* __idx,
+		_TypeTag<_Tp>) noexcept
+      {
+	constexpr size_t _Np = _S_size<_Tp>;
+	return __generate_vector<_Tp, _SimdMember<_Tp>::_S_full_size>([&](
+	  auto __i) constexpr {
+	  return static_cast<_Tp>(__i < _Np ? __mem[__idx[__i]] : 0);
+	});
+      }
+    // _S_gather
+    template <typename _Tp, typename _Up>
+      _GLIBCXX_SIMD_INTRINSIC static _SimdMember<_Tp>
+      _S_gather(const _Up* __mem, const _SimdMember<_Tp>& __idx,
+		_TypeTag<_Tp>) noexcept
+      {
+	constexpr size_t _Np = _S_size<_Tp>;
+	return __generate_vector<_Tp, _SimdMember<_Tp>::_S_full_size>([&](
+	  auto __i) constexpr {
+	  return static_cast<_Tp>(__i < _Np ? __mem[__idx[__i]] : 0);
+	});
+      } // }}}
+
+    // _S_scatter {{{2
+    template <typename _Tp, typename _Up>
+      _GLIBCXX_SIMD_INTRINSIC static void
+      _S_scatter(_SimdMember<_Tp> __v, _Up* __mem,
+		 const __int_for_sizeof_t<_Up>* __idx, _TypeTag<_Tp>) noexcept
+      {
+	constexpr size_t _Np = _S_size<_Tp>;
+	__execute_n_times<_Np>([&](auto __i) constexpr {
+	  __mem[__idx[__i]] = static_cast<_Up>(__v[__i]);
+	});
+      }
+    // _S_scatter
+    template <typename _Tp, typename _Up>
+      _GLIBCXX_SIMD_INTRINSIC static void
+      _S_scatter(_SimdMember<_Tp> __v, _Up* __mem,
+		 const _SimdMember<_Tp>& __idx, _TypeTag<_Tp>) noexcept
+      {
+	constexpr size_t _Np = _S_size<_Tp>;
+	__execute_n_times<_Np>([&](auto __i) constexpr {
+	  __mem[__idx[__i]] = static_cast<_Up>(__v[__i]);
+	});
+      } // }}}
+
     // _S_load {{{2
     template <typename _Tp, typename _Up>
       _GLIBCXX_SIMD_INTRINSIC static _SimdMember<_Tp>
@@ -2284,7 +2332,8 @@ template <typename _Abi>
       const auto __absn = __vector_bitcast<_Ip>(_SuperImpl::_S_abs(__x));
       const auto __maxn
 	= __vector_bitcast<_Ip>(__vector_broadcast<_Np>(__finite_max_v<_Tp>));
-      return __absn <= __maxn;
+      return _MaskImpl::template _S_convert<_Tp>(
+	_MaskImpl::_S_to_bits(__as_wrapper<_Np>(__absn <= __maxn)));
   #endif
     }
 
@@ -2342,11 +2391,13 @@ template <typename _Abi>
       const auto __minn
 	= __vector_bitcast<_Ip>(__vector_broadcast<_Np>(__norm_min_v<_Tp>));
   #if __FINITE_MATH_ONLY__
-      return __absn >= __minn;
+      return  _MaskImpl::template _S_convert<_Tp>(
+        _MaskImpl::_S_to_bits(__as_wrapper<_Np>(__absn >= __minn)));
   #else
       const auto __maxn
 	= __vector_bitcast<_Ip>(__vector_broadcast<_Np>(__finite_max_v<_Tp>));
-      return __minn <= __absn && __absn <= __maxn;
+      return _MaskImpl::template _S_convert<_Tp>(_MaskImpl::_S_to_bits(
+        __as_wrapper<_Np>(__minn <= __absn && __absn <= __maxn)));
   #endif
     }
 
@@ -2837,7 +2888,7 @@ template <typename _Abi>
 
     // smart_reference access {{{2
     template <typename _Tp, size_t _Np>
-      static constexpr void _S_set(_SimdWrapper<_Tp, _Np>& __k, int __i,
+      static constexpr void _S_set(_SimdWrapper<_Tp, _Np>& __k, size_t __i,
 				   bool __x) noexcept
       {
 	if constexpr (is_same_v<_Tp, bool>)

--- a/experimental/bits/simd_scalar.h
+++ b/experimental/bits/simd_scalar.h
@@ -150,6 +150,42 @@ struct _SimdImplScalar
 							      _TypeTag<_Tp>)
     { return __gen(_SizeConstant<0>()); }
 
+  // _S_gather {{{2
+  template <typename _Tp, typename _Up>
+    _GLIBCXX_SIMD_INTRINSIC static _Tp
+    _S_gather(const _Up* __mem, const __int_for_sizeof_t<_Up>* __idx,
+	      _TypeTag<_Tp>) noexcept
+    {
+      return static_cast<_Tp>(__mem[__idx[0]]);
+    }
+
+  // _S_gather
+  template <typename _Tp, typename _Up>
+    _GLIBCXX_SIMD_INTRINSIC static _Tp
+    _S_gather(const _Up* __mem, const _Tp& __idx, _TypeTag<_Tp>) noexcept
+    {
+      return static_cast<_Tp>(__mem[__idx]);
+    } // }}}
+
+  // _S_scatter {{{2
+  template <typename _Tp, typename _Up>
+    _GLIBCXX_SIMD_INTRINSIC static void
+    _S_scatter(const _Tp& __v, _Up* __mem,
+	       [[maybe_unused]] const __int_for_sizeof_t<_Up>* __idx,
+	       _TypeTag<_Tp>) noexcept
+    {
+      __mem[__idx[0]] = static_cast<_Up>(__v);
+    }
+
+  // _S_scatter
+  template <typename _Tp, typename _Up>
+    _GLIBCXX_SIMD_INTRINSIC static void
+    _S_scatter(_Tp& __v, _Up* __mem, [[maybe_unused]] const _Tp& __idx,
+	       _TypeTag<_Tp>) noexcept
+    {
+      __mem[__idx] = static_cast<_Up>(__v);
+    } // }}}
+
   // _S_load {{{2
   template <typename _Tp, typename _Up>
     _GLIBCXX_SIMD_INTRINSIC static _Tp _S_load(const _Up* __mem,


### PR DESCRIPTION
Summary: gather and scatter methods of simd have not supported
those need to be implemented

Test Plan: make test